### PR TITLE
feat: Wait longer to process JQ query

### DIFF
--- a/pkg/utils/jqhelper.go
+++ b/pkg/utils/jqhelper.go
@@ -44,7 +44,7 @@ func JQFilterWithQuery(jqQuery string, jsonInput []byte) ([]byte, error) {
 	}
 
 	// run jq query on input
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	iter := query.RunWithContext(ctx, input)
 	for {
@@ -53,13 +53,13 @@ func JQFilterWithQuery(jqQuery string, jsonInput []byte) ([]byte, error) {
 			break
 		}
 		if err, ok := v.(error); ok {
-			zap.S().Warn("error in processing jq query; error: '%v'", err)
+			zap.S().Warnf("error in processing jq query; error: '%v'", err)
 			continue
 		}
 
 		jqout, err := json.Marshal(v)
 		if err != nil {
-			zap.S().Warn("failed to encode jq output into JSON. error: '%v'", err)
+			zap.S().Warnf("failed to encode jq output into JSON. error: '%v'", err)
 			continue
 		}
 		processed = append(processed, jqout...)


### PR DESCRIPTION
Some large files may take longer than 100ms.

It also fixes a wrong log message, only in this file, there are more in other parts of the project.

Before that:
```
❯ terrascan scan -i tfplan -f large.tfplan.json
2024-08-30T10:30:07.848+0200    warn    utils/jqhelper.go:56    error in processing jq query; error: '%v'context deadline exceeded
2024-08-30T10:30:07.848+0200    error   cli/run.go:141  scan run failed{error 26 0  failed to decode processed jq output. error: 'unexpected end of JSON input'}
```
*Note the wrong log message*

Increase the timeout to 1s it works.