### PR TITLE
Add resource_type to rule properties

### DIFF
--- a/pkg/policy/opa/engine.go
+++ b/pkg/policy/opa/engine.go
@@ -341,11 +341,12 @@ func (e *Engine) reportViolation(regoData *policy.RegoData, resource *output.Res
 // reportPassed Adds a passed rule which wasn't violated by all the resources
 func (e *Engine) reportPassed(regoData *policy.RegoData) {
 	passedRule := results.PassedRule{
-		RuleName:    regoData.Metadata.Name,
-		Description: regoData.Metadata.Description,
-		RuleID:      regoData.Metadata.ID,
-		Severity:    regoData.Metadata.Severity,
-		Category:    regoData.Metadata.Category,
+		RuleName:     regoData.Metadata.Name,
+		Description:  regoData.Metadata.Description,
+		RuleID:       regoData.Metadata.ID,
+		Severity:     regoData.Metadata.Severity,
+		Category:     regoData.Metadata.Category,
+		ResourceType: regoData.Metadata.ResourceType,
 	}
 
 	e.results.ViolationStore.AddPassedRule(&passedRule)

--- a/pkg/results/types.go
+++ b/pkg/results/types.go
@@ -43,11 +43,12 @@ type Violation struct {
 
 // PassedRule contains information of a passed rule
 type PassedRule struct {
-	RuleName    string `json:"rule_name" yaml:"rule_name" xml:"rule_name,attr"`
-	Description string `json:"description" yaml:"description" xml:"description,attr"`
-	RuleID      string `json:"rule_id" yaml:"rule_id" xml:"rule_id,attr"`
-	Severity    string `json:"severity" yaml:"severity" xml:"severity,attr"`
-	Category    string `json:"category" yaml:"category" xml:"category,attr"`
+	RuleName     string `json:"rule_name" yaml:"rule_name" xml:"rule_name,attr"`
+	Description  string `json:"description" yaml:"description" xml:"description,attr"`
+	RuleID       string `json:"rule_id" yaml:"rule_id" xml:"rule_id,attr"`
+	Severity     string `json:"severity" yaml:"severity" xml:"severity,attr"`
+	Category     string `json:"category" yaml:"category" xml:"category,attr"`
+	ResourceType string `json:"resource_type" yaml:"resource_type" xml:"resource_type,attr"`
 }
 
 // ViolationStore Storage area for violation data

--- a/pkg/writer/github_sarif_test.go
+++ b/pkg/writer/github_sarif_test.go
@@ -29,6 +29,7 @@ const violationTemplateForGH = `{
                       },
                       "properties": {
                         "category": "S3",
+                        "resource_type": "aws_s3_bucket",
                         "severity": "HIGH"
                       }
                     }

--- a/pkg/writer/human_readable_test.go
+++ b/pkg/writer/human_readable_test.go
@@ -27,11 +27,12 @@ var (
 		ViolationStore: &results.ViolationStore{
 			PassedRules: []*results.PassedRule{
 				{
-					RuleName:    "s3EnforceUserACL",
-					Description: "S3 bucket Access is allowed to all AWS Account Users.",
-					RuleID:      "AWS.S3Bucket.DS.High.1043",
-					Severity:    "HIGH",
-					Category:    "S3",
+					RuleName:     "s3EnforceUserACL",
+					Description:  "S3 bucket Access is allowed to all AWS Account Users.",
+					RuleID:       "AWS.S3Bucket.DS.High.1043",
+					Severity:     "HIGH",
+					Category:     "S3",
+					ResourceType: "aws_s3_bucket",
 				},
 			},
 			Summary: summaryWithNoViolations,
@@ -53,11 +54,12 @@ var (
 			},
 			PassedRules: []*results.PassedRule{
 				{
-					RuleName:    "s3EnforceUserACL",
-					Description: "S3 bucket Access is allowed to all AWS Account Users.",
-					RuleID:      "AWS.S3Bucket.DS.High.1043",
-					Severity:    "HIGH",
-					Category:    "S3",
+					RuleName:     "s3EnforceUserACL",
+					Description:  "S3 bucket Access is allowed to all AWS Account Users.",
+					RuleID:       "AWS.S3Bucket.DS.High.1043",
+					Severity:     "HIGH",
+					Category:     "S3",
+					ResourceType: "aws_s3_bucket",
 				},
 			},
 			Summary: summaryWithNoViolations,

--- a/pkg/writer/sarif.go
+++ b/pkg/writer/sarif.go
@@ -57,6 +57,7 @@ func writeSarif(data interface{}, writers []io.Writer, forGitHub bool) error {
 	for _, passedRule := range outputData.PassedRules {
 		m := sarif.NewPropertyBag()
 		m.Properties["category"] = passedRule.Category
+		m.Properties["resource_type"] = passedRule.ResourceType
 		m.Properties["severity"] = passedRule.Severity
 
 		run.AddRule(passedRule.RuleID).
@@ -67,6 +68,7 @@ func writeSarif(data interface{}, writers []io.Writer, forGitHub bool) error {
 	for _, violation := range outputData.Violations {
 		m := sarif.NewPropertyBag()
 		m.Properties["category"] = violation.Category
+		m.Properties["resource_type"] = violation.ResourceType
 		m.Properties["severity"] = violation.Severity
 
 		rule := run.AddRule(violation.RuleID).

--- a/pkg/writer/sarif_test.go
+++ b/pkg/writer/sarif_test.go
@@ -35,7 +35,8 @@ const violationTemplate = `{
                       },
                       "properties": {
                         "category": "S3",
-                        "severity": "HIGH"
+                        "severity": "HIGH",
+                        "resource_type": "aws_s3_bucket"
                       }
                     }
                   ],
@@ -113,6 +114,7 @@ var expectedSarifOutput3 = fmt.Sprintf(`{
                       },
                       "properties": {
                         "category": "S3",
+                        "resource_type": "aws_s3_bucket",
                         "severity": "HIGH"
                       }
                     }
@@ -143,6 +145,7 @@ var expectedSarifOutput4 = fmt.Sprintf(`{
                       },
                       "properties": {
                         "category": "S3",
+                        "resource_type": "aws_s3_bucket",
                         "severity": "HIGH"
                       }
                     }


### PR DESCRIPTION
This PR adds the `resource_type` field from the rule metadata to the output of passed rules, and further to the rule properties in the Sarif report.

This field is useful to know which resource rules were applied to, in particular for rules without violations where we have no way of knowing this otherwise.